### PR TITLE
Medium-3170: Lexicographically Minimum String After Removing Stars

### DIFF
--- a/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
+++ b/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
@@ -1,43 +1,45 @@
 package com.dorito.algorithms;
 
+import java.util.Arrays;
+
 public class LexicographicallyMinimumStringAfterRemovingStars {
-    String s = "hello";
-    int length = s.length();
 
     public String minRemoveToMakeValid(String s) {
-        this.s = s;
-        length = s.length();
+
+        char[] chars = s.toCharArray();
+        int[] idxChain = new int[chars.length];
+        int[] idxChainRev = new int[26];
+
+        Arrays.fill(idxChain, -1);
+        Arrays.fill(idxChainRev, -1);
+
+
+        for (int i = 0; i < chars.length; i++) {
+            if(chars[i] == '*') {
+                for (int j = 0; j < 26; j++) {
+                    if(idxChainRev[j] != -1) {
+//                        int idx = idxChainRev[j];
+                        chars[idxChainRev[j]] = '#';
+//                        chars[idx] = '#';
+//                        idxChainRev[j] = idxChain[idx];
+                        idxChainRev[j] = idxChain[idxChainRev[j]];
+                        break;
+                    }
+                }
+                chars[i] = '#';
+            } else {
+                idxChain[i] = idxChainRev[chars[i] - 'a'];
+                idxChainRev[chars[i] - 'a'] = i;
+            }
+        }
 
         StringBuilder sb = new StringBuilder();
+        for (char c : chars) {
+            if (c != '#') {
+                sb.append(c);
+            }
+        }
 
-
-
-        // count the number of stars
-        // if zero, then return the original string.
-        // if stars * 2 == string.length(), then return ""
-
-        // Iterate through string and remove stars
-        // 1)
-        // Find the first star at least index, then remove one character is lexicographically smaller than the previous character
-        // if same lexicographically, delete one any of them.
-        // all the cases should be covered.
-        // dfs 사용 think
-
-        // 2)
-        // delete selected star and char
-
-        // 3) check if the string is empty
-        // if empty, return ""
-
-
-        // base condition:
-        // remove all stars
-
-
-
-        // sorting and return index 0
-
-
-    return "";
+    return sb.toString();
     };
 }

--- a/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
+++ b/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
@@ -1,4 +1,38 @@
 package com.dorito.algorithms;
 
 public class LexicographicallyMinimumStringAfterRemovingStars {
+    String s = "hello";
+    int length = s.length();
+
+    public String minRemoveToMakeValid(String s) {
+        this.s = s;
+        length = s.length();
+
+        StringBuilder sb = new StringBuilder();
+
+
+        // count the number of stars
+        // if zero, then return the original string.
+        // if stars * 2 == string.length(), then return ""
+
+        // Iterate through string and remove stars
+        // 1)
+        // Find the first star at least index, then remove one character is lexicographically smaller than the previous character
+        // if same lexicographically, delete one any of them.
+
+        // 2)
+        // delete selected star and char
+
+        // 3) check if the string is empty
+        // if empty, return ""
+
+        // base condition:
+        // remove all stars
+
+
+
+
+
+    return "";
+    };
 }

--- a/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
+++ b/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
@@ -1,0 +1,4 @@
+package com.dorito.algorithms;
+
+public class LexicographicallyMinimumStringAfterRemovingStars {
+}

--- a/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
+++ b/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
@@ -18,10 +18,7 @@ public class LexicographicallyMinimumStringAfterRemovingStars {
             if(chars[i] == '*') {
                 for (int j = 0; j < 26; j++) {
                     if(idxChainRev[j] != -1) {
-//                        int idx = idxChainRev[j];
                         chars[idxChainRev[j]] = '#';
-//                        chars[idx] = '#';
-//                        idxChainRev[j] = idxChain[idx];
                         idxChainRev[j] = idxChain[idxChainRev[j]];
                         break;
                     }

--- a/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
+++ b/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 
 public class LexicographicallyMinimumStringAfterRemovingStars {
 
-    public String minRemoveToMakeValid(String s) {
+    public String clearStars(String s) {
 
         char[] chars = s.toCharArray();
         int[] idxChain = new int[chars.length];

--- a/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
+++ b/src/main/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStars.java
@@ -11,6 +11,7 @@ public class LexicographicallyMinimumStringAfterRemovingStars {
         StringBuilder sb = new StringBuilder();
 
 
+
         // count the number of stars
         // if zero, then return the original string.
         // if stars * 2 == string.length(), then return ""
@@ -19,6 +20,8 @@ public class LexicographicallyMinimumStringAfterRemovingStars {
         // 1)
         // Find the first star at least index, then remove one character is lexicographically smaller than the previous character
         // if same lexicographically, delete one any of them.
+        // all the cases should be covered.
+        // dfs 사용 think
 
         // 2)
         // delete selected star and char
@@ -26,11 +29,13 @@ public class LexicographicallyMinimumStringAfterRemovingStars {
         // 3) check if the string is empty
         // if empty, return ""
 
+
         // base condition:
         // remove all stars
 
 
 
+        // sorting and return index 0
 
 
     return "";

--- a/src/test/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStarsTest.java
+++ b/src/test/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStarsTest.java
@@ -1,4 +1,323 @@
 package com.dorito.algorithms;
 
-public class LexicographicallyMinimumStringAfterRemovingStarsTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("문자열에서 별표 제거 후 사전순 최소값 찾기 테스트")
+class LexicographicallyMinimumStringAfterRemovingStarsTest {
+
+    private LexicographicallyMinimumStringAfterRemovingStars solution;
+
+    @BeforeEach
+    void setUp() {
+        solution = new LexicographicallyMinimumStringAfterRemovingStars();
+    }
+
+    @Nested
+    @DisplayName("basic test")
+    class BasicTests {
+
+        @Test
+        @DisplayName("별표가 없는 문자열은 그대로 반환되어야 함")
+        void shouldReturnSameStringWhenNoStars() {
+            // Given
+            String input = "abc";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("abc");
+        }
+
+        @Test
+        @DisplayName("단일 문자는 그대로 반환되어야 함")
+        void shouldHandleSingleCharacter() {
+            // Given
+            String input = "a";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("a");
+        }
+    }
+
+    @Nested
+    @DisplayName("예제 케이스 테스트")
+    class ExampleTests {
+
+        @Test
+        @DisplayName("예제 1: aaba* -> aab")
+        void shouldHandleExample1() {
+            // Given
+            String input = "aaba*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("aab");
+        }
+
+        @Test
+        @DisplayName("예제 2: abc -> abc (별표 없음)")
+        void shouldHandleExample2() {
+            // Given
+            String input = "abc";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("abc");
+        }
+    }
+
+    @Nested
+    @DisplayName("별표 처리 테스트")
+    class StarRemovalTests {
+
+        @Test
+        @DisplayName("하나의 별표는 왼쪽에서 사전순으로 가장 작은 문자를 제거해야 함")
+        void shouldRemoveSmallestCharacterToLeft() {
+            // Given
+            String input = "bac*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("bc");
+        }
+
+        @Test
+        @DisplayName("여러 개의 별표는 순차적으로 처리되어야 함")
+        void shouldHandleMultipleStars() {
+            // Given
+            String input = "dcba**";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("dc");
+        }
+
+        @Test
+        @DisplayName("연속된 같은 문자에서 별표 처리 - 가장 오른쪽 문자 제거")
+        void shouldRemoveRightmostOfSameCharacters() {
+            // Given
+            String input = "aaa*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("aa");
+        }
+
+        @Test
+        @DisplayName("별표 앞에 다양한 문자가 있을 때 가장 작은 문자 제거")
+        void shouldRemoveSmallestAmongVariousCharacters() {
+            // Given
+            String input = "zyxabc*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("zyxbc");
+        }
+    }
+
+    @Nested
+    @DisplayName("복잡한 케이스 테스트")
+    class ComplexTests {
+
+        @Test
+        @DisplayName("별표와 문자가 번갈아 나타나는 경우")
+        void shouldHandleAlternatingStarsAndChars() {
+            // Given
+            String input = "a*b*c*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("");
+        }
+
+        @Test
+        @DisplayName("긴 문자열에서 여러 별표 처리")
+        void shouldHandleMultipleStarsInLongString() {
+            // Given
+            String input = "abcdef*g*h*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            // 첫 번째 *: 'a' 제거, 두 번째 *: 'b' 제거, 세 번째 *: 'c' 제거
+            assertThat(result).isEqualTo("defgh");
+        }
+
+        @Test
+        @DisplayName("연속된 별표들 처리")
+        void shouldHandleConsecutiveStars() {
+            // Given
+            String input = "abcd***";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("d");
+        }
+
+        @Test
+        @DisplayName("복잡한 패턴 - 문자열 중간과 끝에 별표")
+        void shouldHandleComplexPattern() {
+            // Given
+            String input = "ab*cd*ef*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            // 첫 번째 *: 'a' 제거, 두 번째 *: 'b' 제거, 세 번째 *: 'c' 제거
+            assertThat(result).isEqualTo("def");
+        }
+
+        @Test
+        @DisplayName("사전순으로 정렬된 문자열에서 별표 처리")
+        void shouldHandleSortedString() {
+            // Given
+            String input = "abcdefg*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("bcdefg");
+        }
+
+        @Test
+        @DisplayName("역순으로 정렬된 문자열에서 별표 처리")
+        void shouldHandleReverseSortedString() {
+            // Given
+            String input = "gfedcba*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("gfedcb");
+        }
+    }
+
+    @Nested
+    @DisplayName("엣지 케이스 테스트")
+    class EdgeCaseTests {
+
+        @Test
+        @DisplayName("별표만 있는 문자열 (제거할 문자가 없음)")
+        void shouldHandleOnlyStars() {
+            // Given
+            String input = "***";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("");
+        }
+
+        @Test
+        @DisplayName("모든 문자가 제거되는 경우")
+        void shouldHandleAllCharactersRemoved() {
+            // Given
+            String input = "a*b*c*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            assertThat(result).isEqualTo("");
+        }
+
+        @Test
+        @DisplayName("최대 길이 문자열 시뮬레이션")
+        void shouldHandleLargeInput() {
+            // Given
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 1000; i++) {
+                sb.append((char)('a' + (i % 26)));
+            }
+            sb.append("*");
+            String input = sb.toString();
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            // 첫 번째 'a'가 제거되고 나머지는 유지되어야 함
+            assertThat(result).hasSize(999);
+            assertThat(result.charAt(0)).isEqualTo('a');
+        }
+
+        @Test
+        @DisplayName("동일한 문자들과 별표의 조합")
+        void shouldHandleIdenticalCharactersWithStars() {
+            // Given
+            String input = "aaaaa*a*a*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            // 5개의 'a' 중 1개 제거, 새로운 'a' 추가 후 제거, 또 새로운 'a' 추가 후 제거
+            // 최종적으로 처음 4개의 'a'만 남음
+            assertThat(result).isEqualTo("aaaa");
+        }
+    }
+
+    @Nested
+    @DisplayName("사전순 최소값 검증 테스트")
+    class LexicographicalMinimumTests {
+
+        @Test
+        @DisplayName("여러 선택지 중 사전순으로 가장 작은 결과 확인")
+        void shouldReturnLexicographicallySmallestResult() {
+            // Given
+            String input = "bacb*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            // 'a'를 제거하면 "bcb", 'b'를 제거하면 "acb" 또는 "bac"
+            // 사전순으로 가장 작은 것은 "acb"가 아니라 "bcb"
+            assertThat(result).isEqualTo("bcb");
+        }
+
+        @Test
+        @DisplayName("복수의 가장 작은 문자 중 아무거나 제거 가능")
+        void shouldRemoveAnyOfSmallestCharacters() {
+            // Given
+            String input = "abab*";
+
+            // When
+            String result = solution.minRemoveToMakeValid(input);
+
+            // Then
+            // 'a' 중 아무거나 제거 가능하므로 "bab" 또는 "abb" 가능
+            // 하지만 알고리즘상 가장 오른쪽 'a'가 제거됨
+            assertThat(result).isEqualTo("abb");
+        }
+    }
 }

--- a/src/test/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStarsTest.java
+++ b/src/test/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStarsTest.java
@@ -1,0 +1,4 @@
+package com.dorito.algorithms;
+
+public class LexicographicallyMinimumStringAfterRemovingStarsTest {
+}

--- a/src/test/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStarsTest.java
+++ b/src/test/java/com/dorito/algorithms/LexicographicallyMinimumStringAfterRemovingStarsTest.java
@@ -27,7 +27,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "abc";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("abc");
@@ -40,7 +40,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "a";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("a");
@@ -58,7 +58,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "aaba*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("aab");
@@ -71,7 +71,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "abc";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("abc");
@@ -89,7 +89,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "bac*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("bc");
@@ -102,7 +102,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "dcba**";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("dc");
@@ -115,7 +115,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "aaa*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("aa");
@@ -128,7 +128,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "zyxabc*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("zyxbc");
@@ -146,7 +146,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "a*b*c*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("");
@@ -159,7 +159,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "abcdef*g*h*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             // 첫 번째 *: 'a' 제거, 두 번째 *: 'b' 제거, 세 번째 *: 'c' 제거
@@ -173,7 +173,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "abcd***";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("d");
@@ -186,7 +186,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "ab*cd*ef*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             // 첫 번째 *: 'a' 제거, 두 번째 *: 'b' 제거, 세 번째 *: 'c' 제거
@@ -200,7 +200,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "abcdefg*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("bcdefg");
@@ -213,7 +213,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "gfedcba*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("gfedcb");
@@ -231,7 +231,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "***";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("");
@@ -244,7 +244,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "a*b*c*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             assertThat(result).isEqualTo("");
@@ -262,7 +262,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = sb.toString();
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             // 첫 번째 'a'가 제거되고 나머지는 유지되어야 함
@@ -277,7 +277,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "aaaaa*a*a*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             // 5개의 'a' 중 1개 제거, 새로운 'a' 추가 후 제거, 또 새로운 'a' 추가 후 제거
@@ -297,7 +297,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "bacb*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             // 'a'를 제거하면 "bcb", 'b'를 제거하면 "acb" 또는 "bac"
@@ -312,7 +312,7 @@ class LexicographicallyMinimumStringAfterRemovingStarsTest {
             String input = "abab*";
 
             // When
-            String result = solution.minRemoveToMakeValid(input);
+            String result = solution.clearStars(input);
 
             // Then
             // 'a' 중 아무거나 제거 가능하므로 "bab" 또는 "abb" 가능


### PR DESCRIPTION
> 문자열을 순회하면서 '*'를 만날 때마다 이전에 나온 문자 중 사전순으로 가장 큰 문자를 효율적으로 제거하는 로직

`link`: https://leetcode.com/problems/lexicographically-minimum-string-after-removing-stars

## Result
<img width="526" alt="image" src="https://github.com/user-attachments/assets/6f078edf-75a0-413c-a4b7-438aaa4cfb0c" />

### 시간 복잡도
- **O(n * k)**: 여기서 n은 입력 문자열의 길이, k는 알파벳 개수(26)
    - 문자열을 순회하는 데 O(n)
    - '*'를 만날 때마다 알파벳을 검사하는 데 O(k)
    - 최종 문자열 생성에 O(n)

### 공간 복잡도
- **O(n)**: 여기서 n은 입력 문자열의 길이
    - 배열: O(n) `chars`
    - 배열: O(n) `idxChain`
    - 배열: O(1) (항상 26 크기) `idxChainRev`
    - StringBuilder: O(n)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to process strings by removing stars and the lexicographically smallest preceding characters to produce a minimal string.
- **Tests**
  - Introduced comprehensive tests covering various scenarios to ensure correct string processing and star removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->